### PR TITLE
fix: Remediate stale lockfile incident and add tests

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
 import unittest
+from pathlib import Path
 
 from openhands_driver import list_skill_ids, select_skill
+
+SKILLS_ROOT = Path(__file__).resolve().parents[1] / ".agents" / "skills"
 
 
 class SkillRouterTests(unittest.TestCase):
@@ -23,6 +32,144 @@ class SkillRouterTests(unittest.TestCase):
             error_report="Probe expects 5000 but process seems on 5001",
         )
         self.assertEqual(skill.skill_id, "port-mismatch")
+
+
+class StaleLockfileSkillTests(unittest.TestCase):
+    """Tests for the stale-lockfile skill's diagnose and remediate functions on host."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.service_proc = None
+        cls.test_port = 15123
+        cls.test_url = f"http://127.0.0.1:{cls.test_port}"
+        cls.lock_path = tempfile.mktemp(prefix="test_service_", suffix=".lock")
+
+    def _start_service(self) -> None:
+        """Start the target service in the background."""
+        app_path = Path(__file__).resolve().parents[1] / "target_service" / "app.py"
+        env = os.environ.copy()
+        env["SCENARIO"] = "stale_lockfile"
+        # Modify app.py to use test port by running with custom PORT env
+        self.service_proc = subprocess.Popen(
+            [sys.executable, "-c", f"""
+import sys
+sys.path.insert(0, '{app_path.parent}')
+import os
+os.environ['SCENARIO'] = 'stale_lockfile'
+LOCKFILE = '{self.lock_path}'
+from flask import Flask, jsonify
+app = Flask(__name__)
+@app.route("/")
+def healthcheck():
+    if os.path.exists(LOCKFILE):
+        return jsonify({{"status": "error", "reason": f"stale lockfile present at {{LOCKFILE}}"}}), 500
+    return jsonify({{"status": "ok", "scenario": "stale_lockfile"}}), 200
+app.run(host="0.0.0.0", port={self.test_port})
+"""],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        # Wait for service to start
+        for _ in range(20):
+            try:
+                result = subprocess.run(
+                    ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", self.test_url],
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                )
+                if result.stdout.strip() in ("200", "500"):
+                    return
+            except Exception:
+                pass
+            time.sleep(0.25)
+        raise RuntimeError("Service did not start in time")
+
+    def _stop_service(self) -> None:
+        """Stop the target service."""
+        if self.service_proc:
+            self.service_proc.terminate()
+            try:
+                self.service_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.service_proc.kill()
+            self.service_proc = None
+
+    def _create_lockfile(self) -> None:
+        """Create a stale lockfile."""
+        Path(self.lock_path).touch()
+
+    def _remove_lockfile(self) -> None:
+        """Remove the lockfile if it exists."""
+        try:
+            os.remove(self.lock_path)
+        except FileNotFoundError:
+            pass
+
+    def setUp(self) -> None:
+        self._remove_lockfile()
+        self._start_service()
+
+    def tearDown(self) -> None:
+        self._stop_service()
+        self._remove_lockfile()
+
+    def test_diagnose_detects_stale_lockfile(self) -> None:
+        """Test that diagnose correctly detects a stale lockfile issue."""
+        sys.path.insert(0, str(SKILLS_ROOT / "stale-lockfile"))
+        from diagnose import diagnose
+
+        # First verify service is healthy without lockfile
+        result = diagnose(
+            target_url=self.test_url,
+            target_container=None,
+            lock_path=self.lock_path,
+        )
+        self.assertEqual(result["http_code"], "200")
+        self.assertFalse(result["present"])
+        self.assertFalse(result["is_stale_lockfile_candidate"])
+
+        # Now create lockfile and verify diagnosis
+        self._create_lockfile()
+        result = diagnose(
+            target_url=self.test_url,
+            target_container=None,
+            lock_path=self.lock_path,
+        )
+        self.assertEqual(result["http_code"], "500")
+        self.assertTrue(result["present"])
+        self.assertTrue(result["is_stale_lockfile_candidate"])
+
+    def test_remediate_fixes_stale_lockfile(self) -> None:
+        """Test that remediate correctly removes stale lockfile and fixes service."""
+        sys.path.insert(0, str(SKILLS_ROOT / "stale-lockfile"))
+        from remediate import remediate
+
+        # Create lockfile to simulate stale state
+        self._create_lockfile()
+
+        # Verify service is unhealthy
+        result = subprocess.run(
+            ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", self.test_url],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout.strip(), "500")
+
+        # Apply remediation
+        result = remediate(
+            target_url=self.test_url,
+            target_container=None,
+            lock_path=self.lock_path,
+        )
+        self.assertEqual(result["pre_http_code"], "500")
+        self.assertEqual(result["post_http_code"], "200")
+        self.assertTrue(result["fixed"])
+        self.assertEqual(result["scope"], "host")
+
+        # Verify lockfile is gone
+        self.assertFalse(Path(self.lock_path).exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes #8 - Service returning HTTP 500 due to stale lockfile

## Incident Report

### Diagnosis
Service was returning HTTP 500 due to a stale lockfile at `/tmp/service.lock`.
The lockfile was left behind after a previous crash, blocking service startup.

### Risk Assessment

| Action | Risk | Rationale |
|--------|------|-----------|
| `curl -i http://127.0.0.1:15000` | LOW | Read-only health check |
| `rm -f /tmp/service.lock` | MEDIUM | Removes temp file only, service unaffected |

### Remediation
Applied the stale-lockfile skill runbook:
1. Diagnosed the issue (HTTP 500, lockfile present)
2. Removed the stale lockfile: `rm -f /tmp/service.lock`
3. Verified service returned HTTP 200

### Verification
- Service returns HTTP 200 with healthy status
- Lock file is absent
- All tests pass

## Changes
This PR adds comprehensive unit tests for the stale-lockfile skill that verify the `diagnose` and `remediate` functions work correctly when running on a host (without Docker).

### New Tests
- `test_diagnose_detects_stale_lockfile`: Verifies the skill correctly identifies when a stale lockfile is causing HTTP 500 errors
- `test_remediate_fixes_stale_lockfile`: Verifies the skill correctly removes the lockfile and restores service health

## Testing
```bash
cd openhands-sre
PYTHONPATH=. python -m pytest tests/test_skills.py -v
```

All 5 tests in `test_skills.py` pass, including the 2 new stale-lockfile skill tests.