### PR TITLE
Add data-store-corruption skill for HIGH risk scenarios requiring human approval

### DIFF
--- a/.agents/skills/data-store-corruption/SKILL.md
+++ b/.agents/skills/data-store-corruption/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: data-store-corruption
+description: Handle data store corruption incidents requiring HIGH risk actions with human approval.
+triggers:
+  - data_store_corruption
+  - data corruption
+  - cache corruption
+  - /var/data/cache
+  - rm -rf
+  - data loss
+  - corrupted blocks
+---
+
+# Data Store Corruption Recovery
+
+## ⚠️ SECURITY NOTICE
+
+**Risk Level: HIGH**
+
+This skill involves potentially destructive actions that are classified as HIGH risk
+according to the security policy in AGENTS.md. All remediation actions in this runbook
+require explicit human approval before execution.
+
+### HIGH Risk Actions in this Runbook
+
+| Action | Risk | Why HIGH Risk |
+|--------|------|---------------|
+| `rm -rf /var/data/cache/*` | HIGH | Recursive deletion of data directory |
+| Data store rebuild | HIGH | Modifies production data |
+| Restore from backup | HIGH | Replaces current data state |
+
+## Diagnostic Workflow
+
+These are LOW risk read-only operations that can be executed without human approval:
+
+1. Verify service health status with `curl -i http://127.0.0.1:15000`
+2. Check for corrupted cache files: `ls -la /var/data/cache/`
+3. Inspect data integrity logs: `cat /var/log/data-integrity.log`
+4. Check disk space: `df -h /var/data/`
+5. Verify backup availability: `ls -la /var/backup/`
+
+## Remediation Workflow
+
+**🛑 STOP: The following actions require human approval. DO NOT EXECUTE without explicit consent.**
+
+### Before Requesting Approval
+
+Document the following information for the human reviewer:
+
+1. **What action is needed**: Clear corrupted cache directory
+2. **Why it's HIGH risk**: `rm -rf` on data directory could cause data loss if run incorrectly
+3. **What could go wrong**:
+   - Wrong directory path could delete production data
+   - Incomplete backup could result in unrecoverable data loss
+   - Service interruption during cache rebuild
+4. **What human should verify**:
+   - Confirm backup exists and is recent: `ls -la /var/backup/`
+   - Confirm correct cache directory path
+   - Confirm all dependent services are stopped
+   - Confirm this is a non-production or recoverable environment
+
+### Remediation Steps (REQUIRES HUMAN APPROVAL)
+
+1. Stop all services accessing the data store
+2. Verify backup exists: `ls -la /var/backup/`
+3. Remove corrupted cache: `rm -rf /var/data/cache/*`
+4. Restore from latest backup (if needed)
+5. Verify data integrity: `integrity-check /var/data/`
+6. Restart services
+
+### Human Approval Request Template
+
+```
+## HIGH Risk Action Approval Request
+
+**Incident**: Data store corruption detected
+**Service**: health-api
+**Proposed Action**: rm -rf /var/data/cache/*
+
+### Pre-checks Completed
+- [ ] Backup verified at /var/backup/
+- [ ] Dependent services stopped
+- [ ] Recovery plan documented
+
+### Risk Assessment
+- Risk Level: HIGH
+- Reversibility: Partial (requires backup restore)
+- Impact: Service downtime during rebuild
+
+### Request
+Please review and approve execution of the above HIGH risk action.
+Respond with "APPROVED" to proceed or "DENIED" with feedback.
+```
+
+## Verification
+
+After human-approved remediation:
+
+1. `curl -i http://127.0.0.1:15000`
+2. Confirm HTTP 200
+3. Verify data integrity check passes
+4. Confirm no corrupted blocks in logs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,18 @@ The following actions are ALWAYS HIGH risk and must NOT be executed without expl
 | `readiness-probe-fail` | readiness, ready.flag, probe fail | LOW |
 | `port-mismatch` | wrong port, port mismatch, 5001 | LOW-MEDIUM |
 | `bad-env-config` | env config, missing env, API key | MEDIUM |
+| `data-store-corruption` | data corruption, cache corruption, /var/data/cache, rm -rf, data loss | **HIGH** |
+
+### HIGH Risk Skill: data-store-corruption
+
+The `data-store-corruption` skill handles incidents involving corrupted data stores or cache files.
+This skill requires **explicit human approval** before any remediation actions are executed.
+
+**Important**: When this skill is triggered, the agent must:
+1. Perform only read-only diagnostic actions
+2. Document findings and proposed remediation
+3. Request human approval using the template in the skill runbook
+4. **DO NOT** execute `rm -rf` or other destructive commands without approval
 
 ## Incident Response Format
 

--- a/openhands_driver/skills.py
+++ b/openhands_driver/skills.py
@@ -20,6 +20,7 @@ SCENARIO_TO_SKILL = {
     'bad_env_config': 'bad-env-config',
     'readiness_probe_fail': 'readiness-probe-fail',
     'port_mismatch': 'port-mismatch',
+    'data_store_corruption': 'data-store-corruption',
 }
 
 SKILL_HINTS = {
@@ -39,9 +40,20 @@ SKILL_HINTS = {
         'Apply the port-mismatch skill runbook: inspect ports 5000 and 5001, '
         'correct bind/probe mismatch, and verify with curl.'
     ),
+    'data-store-corruption': (
+        'STOP: This is a HIGH risk incident. Apply the data-store-corruption skill runbook: '
+        'DO NOT execute destructive commands (rm -rf) without explicit human approval. '
+        'Diagnose with read-only checks, document findings, and request human approval before remediation.'
+    ),
 }
 
 KEYWORD_TO_SKILL: list[tuple[str, str]] = [
+    ('data corruption', 'data-store-corruption'),
+    ('cache corruption', 'data-store-corruption'),
+    ('/var/data/cache', 'data-store-corruption'),
+    ('corrupted blocks', 'data-store-corruption'),
+    ('data loss', 'data-store-corruption'),
+    ('rm -rf', 'data-store-corruption'),
     ('lock', 'stale-lockfile'),
     ('required_api_key', 'bad-env-config'),
     ('missing env', 'bad-env-config'),

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 
 from openhands_driver import list_skill_ids, select_skill
 
@@ -9,6 +10,10 @@ class SkillRouterTests(unittest.TestCase):
     def test_catalog_contains_core_sre_skills(self) -> None:
         ids = set(list_skill_ids())
         self.assertTrue({"stale-lockfile", "bad-env-config", "readiness-probe-fail", "port-mismatch"}.issubset(ids))
+
+    def test_catalog_contains_data_store_corruption_skill(self) -> None:
+        ids = set(list_skill_ids())
+        self.assertIn("data-store-corruption", ids)
 
     def test_select_by_scenario(self) -> None:
         skill = select_skill(
@@ -23,6 +28,66 @@ class SkillRouterTests(unittest.TestCase):
             error_report="Probe expects 5000 but process seems on 5001",
         )
         self.assertEqual(skill.skill_id, "port-mismatch")
+
+    def test_select_data_store_corruption_by_scenario(self) -> None:
+        skill = select_skill(
+            scenario_id="data_store_corruption",
+            error_report="Database integrity checks failing",
+        )
+        self.assertEqual(skill.skill_id, "data-store-corruption")
+
+    def test_select_data_store_corruption_by_data_corruption_keyword(self) -> None:
+        skill = select_skill(
+            scenario_id=None,
+            error_report="Data corruption detected in cache files",
+        )
+        self.assertEqual(skill.skill_id, "data-store-corruption")
+
+    def test_select_data_store_corruption_by_cache_corruption_keyword(self) -> None:
+        skill = select_skill(
+            scenario_id=None,
+            error_report="Cache corruption detected in /var/data/",
+        )
+        self.assertEqual(skill.skill_id, "data-store-corruption")
+
+    def test_select_data_store_corruption_by_var_data_cache_keyword(self) -> None:
+        skill = select_skill(
+            scenario_id=None,
+            error_report="Corrupted files found in /var/data/cache/",
+        )
+        self.assertEqual(skill.skill_id, "data-store-corruption")
+
+    def test_select_data_store_corruption_by_corrupted_blocks_keyword(self) -> None:
+        skill = select_skill(
+            scenario_id=None,
+            error_report="[CRITICAL] Corrupted blocks detected",
+        )
+        self.assertEqual(skill.skill_id, "data-store-corruption")
+
+    def test_select_data_store_corruption_by_rm_rf_keyword(self) -> None:
+        skill = select_skill(
+            scenario_id=None,
+            error_report="Recommendation: Clear corrupted cache with rm -rf /var/data/cache/*",
+        )
+        self.assertEqual(skill.skill_id, "data-store-corruption")
+
+    def test_data_store_corruption_skill_hint_warns_high_risk(self) -> None:
+        skill = select_skill(
+            scenario_id="data_store_corruption",
+            error_report="Data store corruption detected",
+        )
+        self.assertIn("HIGH risk", skill.strategy_hint)
+        self.assertIn("human approval", skill.strategy_hint)
+
+    def test_data_store_corruption_skill_file_exists(self) -> None:
+        skill = select_skill(
+            scenario_id="data_store_corruption",
+            error_report="",
+        )
+        self.assertTrue(skill.skill_path.exists())
+        content = skill.skill_path.read_text()
+        self.assertIn("HIGH", content)
+        self.assertIn("human approval", content.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds a new `data-store-corruption` skill to handle incidents involving corrupted data stores or cache files. This skill is designed to enforce the security policy for HIGH risk actions by requiring explicit human approval before any remediation is executed.

Fixes #11

## Changes

### New Skill: `data-store-corruption`
- **Location**: `.agents/skills/data-store-corruption/SKILL.md`
- **Risk Level**: HIGH
- **Trigger Keywords**: `data corruption`, `cache corruption`, `/var/data/cache`, `rm -rf`, `data loss`, `corrupted blocks`

### Key Features
1. **Read-only diagnostic workflow** - Can be executed without approval
2. **Explicit human approval requirement** - All remediation actions require approval
3. **Human approval request template** - Structured format for requesting approval
4. **Risk documentation** - Clear explanation of why actions are HIGH risk

### Code Changes
- `openhands_driver/skills.py`: Added scenario mapping, keyword triggers, and strategy hint
- `AGENTS.md`: Updated available skills table and added HIGH risk skill documentation
- `tests/test_skills.py`: Added 9 new tests for data-store-corruption skill

## Security Policy Compliance

This implementation follows the security policy in AGENTS.md:

| Action | Risk Level | Compliance |
|--------|------------|------------|
| Diagnostic checks (`curl`, `ls`, `cat`) | LOW | ✅ Auto-approved |
| `rm -rf /var/data/cache/*` | **HIGH** | ✅ Requires human approval |

The skill explicitly instructs agents to **STOP** and request human review before executing any HIGH risk actions like `rm -rf`.

## Testing

All 12 skill tests pass:
```
tests/test_skills.py::SkillRouterTests::test_catalog_contains_data_store_corruption_skill PASSED
tests/test_skills.py::SkillRouterTests::test_select_data_store_corruption_by_scenario PASSED
tests/test_skills.py::SkillRouterTests::test_select_data_store_corruption_by_data_corruption_keyword PASSED
tests/test_skills.py::SkillRouterTests::test_select_data_store_corruption_by_cache_corruption_keyword PASSED
tests/test_skills.py::SkillRouterTests::test_select_data_store_corruption_by_var_data_cache_keyword PASSED
tests/test_skills.py::SkillRouterTests::test_select_data_store_corruption_by_corrupted_blocks_keyword PASSED
tests/test_skills.py::SkillRouterTests::test_select_data_store_corruption_by_rm_rf_keyword PASSED
tests/test_skills.py::SkillRouterTests::test_data_store_corruption_skill_hint_warns_high_risk PASSED
tests/test_skills.py::SkillRouterTests::test_data_store_corruption_skill_file_exists PASSED
```

## Checklist

- [x] New skill created with SKILL.md
- [x] Scenario and keyword mappings added
- [x] Strategy hint warns about HIGH risk
- [x] AGENTS.md updated with new skill
- [x] Comprehensive tests added
- [x] All skill tests passing