### PR TITLE
Fix: Add unit tests for stale-lockfile skill remediation

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -11,7 +11,9 @@ from openhands_driver import list_skill_ids, select_skill
 # Add skill directories to path for imports
 ROOT = Path(__file__).resolve().parents[1]
 READINESS_SKILL_PATH = ROOT / ".agents" / "skills" / "readiness-probe-fail"
+STALE_LOCKFILE_SKILL_PATH = ROOT / ".agents" / "skills" / "stale-lockfile"
 sys.path.insert(0, str(READINESS_SKILL_PATH))
+sys.path.insert(0, str(STALE_LOCKFILE_SKILL_PATH))
 
 
 class SkillRouterTests(unittest.TestCase):
@@ -89,6 +91,53 @@ class ReadinessProbeSkillTests(unittest.TestCase):
         self.assertEqual(result["touch_returncode"], 0)
         self.assertEqual(result["touch_error"], "")
         self.assertTrue(os.path.exists(self.ready_path))
+
+
+class StaleLockfileSkillTests(unittest.TestCase):
+    """Test stale-lockfile skill diagnose and remediate functions on host filesystem."""
+
+    def setUp(self) -> None:
+        self.lock_path = "/tmp/test_service.lock"
+        if os.path.exists(self.lock_path):
+            os.remove(self.lock_path)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.lock_path):
+            os.remove(self.lock_path)
+
+    def test_diagnose_detects_missing_lockfile(self) -> None:
+        """Test diagnose detects when no lockfile is present."""
+        # Import from stale-lockfile skill directory (already on sys.path)
+        from diagnose import _host_file_state
+        result = _host_file_state(self.lock_path)
+        self.assertFalse(result["present"])
+        self.assertEqual(result["error"], "")
+
+    def test_diagnose_detects_existing_lockfile(self) -> None:
+        """Test diagnose detects when lockfile exists."""
+        from diagnose import _host_file_state
+        Path(self.lock_path).touch()
+        result = _host_file_state(self.lock_path)
+        self.assertTrue(result["present"])
+        self.assertEqual(result["error"], "")
+
+    def test_remediate_removes_lockfile_on_host(self) -> None:
+        """Test that remediation removes the lockfile on host when no container is specified."""
+        from remediate import remediate
+
+        Path(self.lock_path).touch()
+        self.assertTrue(os.path.exists(self.lock_path))
+
+        result = remediate(
+            target_url="http://127.0.0.1:9999",
+            target_container=None,
+            lock_path=self.lock_path,
+        )
+
+        self.assertEqual(result["scope"], "host")
+        self.assertEqual(result["remove_returncode"], 0)
+        self.assertEqual(result["remove_error"], "")
+        self.assertFalse(os.path.exists(self.lock_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Skill Used
`stale-lockfile`

## Incident Summary
Resolved incident #13: Service returning HTTP 500 due to stale lockfile at `/tmp/service.lock`.

## Diagnosis
- **HTTP Code**: 500 (Internal Server Error)
- **Root Cause**: Stale lockfile present at `/tmp/service.lock`
- **is_stale_lockfile_candidate**: true

## Risk Assessment
| Action | Risk Level | Rationale |
|--------|------------|-----------|
| `curl -i http://service:5000` | LOW | Read-only health check |
| `rm -f /tmp/service.lock` | MEDIUM | Removes temp lockfile only, service unaffected by file deletion |

## Remediation
1. Ran `diagnose.py` to confirm stale lockfile condition
2. Ran `remediate.py` to remove `/tmp/service.lock`
3. Verified service returned HTTP 200 after remediation

## Verification
- **Pre-remediation HTTP code**: 500
- **Post-remediation HTTP code**: 200
- **Lockfile removed**: ✅

## Changes
- Added `StaleLockfileSkillTests` test class with 3 unit tests:
  - `test_diagnose_detects_missing_lockfile`: Verifies diagnose detects when lockfile is absent
  - `test_diagnose_detects_existing_lockfile`: Verifies diagnose detects when lockfile exists
  - `test_remediate_removes_lockfile_on_host`: Verifies remediate removes the lockfile on host

All tests passing.

Fixes #13