### PR TITLE
Fix service2 readiness probe failing in multi-scenario mode

### DIFF
--- a/target_service/start.sh
+++ b/target_service/start.sh
@@ -29,5 +29,9 @@ fi
 
 # Multi-scenario mode: no SCENARIO env var means all paths work independently
 # Each path (/service1, /service2, /service3) checks its own conditions
+# In multi-scenario mode, create ready.flag so service2 is healthy by default
+if [ -z "${SCENARIO:-}" ]; then
+  touch /tmp/ready.flag
+fi
 
 exec python /app/app.py

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -122,6 +122,63 @@ class TargetServiceIntegrationTests(unittest.TestCase):
         finally:
             self._stop_container(name)
 
+    def _start_multiscenario_container(self) -> str:
+        """Start container in multi-scenario mode (no SCENARIO env var)."""
+        name = f"openhands-gepa-it-multi-{uuid.uuid4().hex[:6]}"
+        self._run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                name,
+                "-e",
+                "REQUIRED_API_KEY=test-key",
+                IMAGE,
+            ]
+        )
+        self._wait_for_service(name)
+        return name
+
+    def _container_http_status_path(self, name: str, path: str) -> str:
+        """Get HTTP status for a specific path."""
+        return self._run(
+            [
+                "docker",
+                "exec",
+                name,
+                "sh",
+                "-lc",
+                f"curl -s -o /dev/null -w '%{{http_code}}' localhost:5000{path}",
+            ]
+        )
+
+    def test_multiscenario_service2_healthy_by_default(self) -> None:
+        """Test that service2 is healthy in multi-scenario mode (ready.flag created at startup)."""
+        name = self._start_multiscenario_container()
+        try:
+            status = self._container_http_status_path(name, "/service2")
+            self.assertEqual(status, "200", "service2 should be healthy by default in multi-scenario mode")
+
+            self._run(["docker", "exec", name, "sh", "-lc", "ls -la /tmp/ready.flag"])
+        finally:
+            self._stop_container(name)
+
+    def test_multiscenario_all_services_healthy(self) -> None:
+        """Test that all services are healthy in multi-scenario mode."""
+        name = self._start_multiscenario_container()
+        try:
+            status1 = self._container_http_status_path(name, "/service1")
+            status2 = self._container_http_status_path(name, "/service2")
+            status3 = self._container_http_status_path(name, "/service3")
+
+            self.assertEqual(status1, "200", "service1 should be healthy")
+            self.assertEqual(status2, "200", "service2 should be healthy")
+            self.assertEqual(status3, "200", "service3 should be healthy (with REQUIRED_API_KEY set)")
+        finally:
+            self._stop_container(name)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #17 - 🚨 Incident: service2 readiness probe failing - service not ready

## Skill Used
`readiness-probe-fail` - Resolve readiness probe failures when startup appears successful but health checks fail.

## Diagnosis
In multi-scenario mode (when `SCENARIO` env var is not set), the `start.sh` script was:
1. Removing `/tmp/ready.flag` on boot (line 5)
2. Not recreating the flag for multi-scenario mode

This caused service2 (`/service2` endpoint) to always fail readiness probes with HTTP 500 in multi-scenario mode, because the Flask app checks for the existence of `/tmp/ready.flag`.

## Risk Assessment

| Action | Risk Level | Rationale |
|--------|------------|-----------|
| Create `/tmp/ready.flag` in startup script | LOW | Creates a flag file only, no state modification |

## Remediation
Modified `target_service/start.sh` to create `/tmp/ready.flag` in multi-scenario mode:

```bash
# In multi-scenario mode, create ready.flag so service2 is healthy by default
if [ -z "${SCENARIO:-}" ]; then
  touch /tmp/ready.flag
fi
```

This preserves the existing single-scenario (legacy) behavior where `SCENARIO=readiness_probe_fail` still causes service2 to start in a broken state for testing purposes.

## Verification

Added integration tests that verify:
- `test_multiscenario_service2_healthy_by_default`: service2 returns HTTP 200 in multi-scenario mode
- `test_multiscenario_all_services_healthy`: all services (service1, service2, service3) are healthy in multi-scenario mode

All 4 tests pass:
```
tests/test_integration.py::TargetServiceIntegrationTests::test_multiscenario_all_services_healthy PASSED
tests/test_integration.py::TargetServiceIntegrationTests::test_multiscenario_service2_healthy_by_default PASSED
tests/test_integration.py::TargetServiceIntegrationTests::test_readiness_probe_recovers_500_to_200 PASSED
tests/test_integration.py::TargetServiceIntegrationTests::test_stale_lockfile_recovers_500_to_200 PASSED
```

## Changes
- `target_service/start.sh`: Create `/tmp/ready.flag` in multi-scenario mode
- `tests/test_integration.py`: Add tests for multi-scenario mode healthiness