### PR TITLE
fix: Incident response for service1 HTTP 500 - stale lockfile (issue #32)

### DIFF
--- a/docs/incidents/incident-32-stale-lockfile.md
+++ b/docs/incidents/incident-32-stale-lockfile.md
@@ -1,0 +1,74 @@
+# Incident Response: Service1 HTTP 500 - Stale Lockfile
+
+**Incident ID**: #32  
+**Service**: service1 (health-api)  
+**Endpoint**: `/service1`  
+**Status**: RESOLVED  
+**Skill Used**: `stale-lockfile`
+
+## Incident Summary
+
+Service1 was returning HTTP 500 Internal Server Error due to a stale lockfile at `/tmp/service.lock` that persisted after a previous process crash.
+
+## Symptoms
+
+- Health endpoint returning 500 status code
+- Error message: "stale lockfile present at /tmp/service.lock"
+- Service was healthy before last deployment
+
+## Root Cause
+
+The service creates a lockfile at `/tmp/service.lock` on startup to prevent multiple instances. If the service crashes without cleanup, this lockfile persists and blocks subsequent startups, causing HTTP 500 errors.
+
+## Diagnosis
+
+Used `diagnose_service1` MCP tool (LOW risk - read-only) to confirm:
+- Lockfile exists at `/tmp/service.lock`
+- No owning process running
+- HTTP status: 500
+
+Manual verification command:
+```bash
+docker exec openhands-gepa-demo ls -la /tmp/service.lock
+```
+
+## Remediation
+
+### Actions Taken
+
+| Action | Risk Level | Rationale |
+|--------|------------|-----------|
+| `diagnose_service1` | LOW | Read-only diagnostic check |
+| `fix_service1` | MEDIUM | Removes temp lockfile at `/tmp/service.lock` |
+| `curl /service1` | LOW | Read-only verification |
+
+### Fix Applied
+
+Used `fix_service1` MCP tool to remove the stale lockfile:
+```bash
+rm -f /tmp/service.lock
+```
+
+**Risk Level**: MEDIUM - Removes a temporary file only; no data loss risk.
+
+## Verification
+
+1. Service returns HTTP 200 after fix
+2. Response contains `"status": "ok"`
+3. Lockfile is absent
+
+```bash
+curl -i https://TARGET_URL/service1
+# Expected: HTTP 200 with {"status": "ok", "scenario": "stale_lockfile"}
+```
+
+## Prevention
+
+- Implement proper signal handlers for graceful shutdown
+- Use lockfile with PID check to detect stale locks automatically
+- Add startup script to clean stale locks if owning process is not running
+
+## References
+
+- Skill: `.agents/skills/stale-lockfile/SKILL.md`
+- MCP Tools: `diagnose_service1`, `fix_service1`

--- a/tests/test_lockfile_scenario.py
+++ b/tests/test_lockfile_scenario.py
@@ -1,0 +1,80 @@
+"""Unit tests for the stale lockfile scenario.
+
+These tests verify the lockfile remediation logic without requiring Docker.
+Related to incident #32: service1 returning HTTP 500 due to stale lockfile.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'target_service'))
+
+from app import app, LOCKFILE
+
+
+class StaleLockfileScenarioTests(unittest.TestCase):
+    """Test the stale lockfile scenario without Docker."""
+
+    def setUp(self):
+        self.client = app.test_client()
+        self.temp_lockfile = tempfile.mktemp()
+        self._original_lockfile = LOCKFILE
+        
+    def tearDown(self):
+        if os.path.exists(self.temp_lockfile):
+            os.remove(self.temp_lockfile)
+
+    def test_service1_returns_500_when_lockfile_present(self):
+        """Service1 should return 500 when lockfile exists."""
+        with patch('app.LOCKFILE', self.temp_lockfile):
+            # Create the lockfile
+            with open(self.temp_lockfile, 'w') as f:
+                f.write('locked')
+            
+            # Simulate JSON client (curl)
+            response = self.client.get('/service1', headers={'User-Agent': 'curl/7.x'})
+            self.assertEqual(response.status_code, 500)
+            data = response.get_json()
+            self.assertEqual(data['status'], 'error')
+            self.assertIn('stale lockfile', data['reason'])
+
+    def test_service1_returns_200_after_lockfile_removed(self):
+        """Service1 should return 200 after lockfile is removed (remediation)."""
+        with patch('app.LOCKFILE', self.temp_lockfile):
+            # Create the lockfile first
+            with open(self.temp_lockfile, 'w') as f:
+                f.write('locked')
+            
+            # Verify it's broken
+            response = self.client.get('/service1', headers={'User-Agent': 'curl/7.x'})
+            self.assertEqual(response.status_code, 500)
+            
+            # Remediation: Remove the lockfile (simulates fix_service1)
+            os.remove(self.temp_lockfile)
+            
+            # Verify service is healthy
+            response = self.client.get('/service1', headers={'User-Agent': 'curl/7.x'})
+            self.assertEqual(response.status_code, 200)
+            data = response.get_json()
+            self.assertEqual(data['status'], 'ok')
+            self.assertEqual(data['scenario'], 'stale_lockfile')
+
+    def test_service1_healthy_when_no_lockfile(self):
+        """Service1 should be healthy when no lockfile exists."""
+        with patch('app.LOCKFILE', self.temp_lockfile):
+            # Ensure lockfile doesn't exist
+            if os.path.exists(self.temp_lockfile):
+                os.remove(self.temp_lockfile)
+            
+            response = self.client.get('/service1', headers={'User-Agent': 'curl/7.x'})
+            self.assertEqual(response.status_code, 200)
+            data = response.get_json()
+            self.assertEqual(data['status'], 'ok')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR documents the incident remediation for service1 returning HTTP 500 due to a stale lockfile at `/tmp/service.lock`.

Fixes #32

## Skill Used

`stale-lockfile` (from `.agents/skills/stale-lockfile/SKILL.md`)

## Diagnosis

The service health endpoint was returning HTTP 500 with error message:
```
"stale lockfile present at /tmp/service.lock"
```

**Diagnosis Tools:**
- `diagnose_service1` MCP tool (LOW risk - read-only health check)

## Risk Assessment

| Action | Risk Level | Rationale |
|--------|------------|-----------|
| `diagnose_service1` | LOW | Read-only diagnostic check |
| `fix_service1` | MEDIUM | Removes temp lockfile at `/tmp/service.lock` |
| `curl /service1` | LOW | Read-only verification |

## Remediation

Applied fix using `fix_service1` MCP tool which executes:
```bash
rm -f /tmp/service.lock
```

**Risk Level**: MEDIUM - Removes a temporary file only; no data loss risk. Auto-approved per AGENTS.md policy.

## Verification

After lockfile removal:
1. ✅ Service returns HTTP 200
2. ✅ Response contains `"status": "ok"`
3. ✅ Lockfile is absent

## Changes

- **docs/incidents/incident-32-stale-lockfile.md**: Incident response documentation with full remediation details
- **tests/test_lockfile_scenario.py**: Unit tests for the stale lockfile scenario (3 tests, all passing)
  - `test_service1_returns_500_when_lockfile_present`
  - `test_service1_returns_200_after_lockfile_removed`
  - `test_service1_healthy_when_no_lockfile`

## Testing

```bash
python -m pytest tests/test_lockfile_scenario.py -v
# 3 passed in 0.19s
```

## Prevention Recommendations

- Implement proper signal handlers for graceful shutdown
- Use lockfile with PID check to detect stale locks automatically
- Add startup script to clean stale locks if owning process is not running