### PR TITLE
Fix: Remove stale lockfile from service1 (issue #131)

### DIFF
--- a/INCIDENT-131.md
+++ b/INCIDENT-131.md
@@ -1,0 +1,93 @@
+# Incident Report: Service1 Stale Lockfile (Issue #131)
+
+## Skill Used
+`stale-lockfile` (from `.agents/skills/stale-lockfile/SKILL.md`)
+
+## Diagnosis
+
+**Service:** service1  
+**Endpoint:** `/service1`  
+**Initial Status:** HTTP 500 Internal Server Error  
+**Root Cause:** Stale lockfile present at `/tmp/service.lock`
+
+### Diagnostic Output
+
+**Initial Service Status:**
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "500",
+    "healthy": false
+  }
+}
+```
+
+**Service1 Diagnosis:**
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1"
+}
+```
+
+## Risk Assessment
+
+| Action | Risk Level | Justification |
+|--------|------------|---------------|
+| `diagnose_service1` | LOW | Read-only health check and file existence verification |
+| `fix_service1` (rm -f /tmp/service.lock) | MEDIUM | Removes temporary lockfile only; service automatically recovers |
+| `get_all_service_status` | LOW | Read-only HTTP health check |
+
+**Risk Level: MEDIUM** (auto-approved per AGENTS.md security policy)
+
+The remediation action is classified as MEDIUM risk because it modifies filesystem state by removing a file. However, the file is a temporary lockfile (`/tmp/service.lock`) that was left behind from a previous crash. Removing it allows the service to restart normally without affecting any persistent data or configuration.
+
+## Remediation
+
+**Action Executed:** `fix_service1`  
+**Command:** `rm -f /tmp/service.lock`
+
+### Remediation Output
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+## Verification
+
+**Post-Fix Service Status:**
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "200",
+    "healthy": true
+  }
+}
+```
+
+✅ Service1 is now returning HTTP 200 with healthy status.
+
+## Summary
+
+Successfully resolved stale lockfile issue on service1 by:
+1. Confirming HTTP 500 error via `get_all_service_status`
+2. Diagnosing lockfile presence via `diagnose_service1`
+3. Removing stale lockfile via `fix_service1` (MEDIUM risk, auto-approved)
+4. Verifying service recovery (HTTP 200) via `get_all_service_status`
+
+The service is now operational and returning the expected `"status": "ok"` response.


### PR DESCRIPTION
## Skill Used
`stale-lockfile` (from `.agents/skills/stale-lockfile/SKILL.md`)

## Diagnosis

**Service:** service1  
**Endpoint:** `/service1`  
**Initial Status:** HTTP 500 Internal Server Error  
**Root Cause:** Stale lockfile present at `/tmp/service.lock`

### Diagnostic Output

**Initial Service Status:**
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "500",
    "healthy": false
  }
}
```

**Service1 Diagnosis:**
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

## Risk Assessment

| Action | Risk Level | Justification |
|--------|------------|---------------|
| `diagnose_service1` | LOW | Read-only health check and file existence verification |
| `fix_service1` (rm -f /tmp/service.lock) | MEDIUM | Removes temporary lockfile only; service automatically recovers |
| `get_all_service_status` | LOW | Read-only HTTP health check |

**Risk Level: MEDIUM** (auto-approved per AGENTS.md security policy)

The remediation action is classified as MEDIUM risk because it modifies filesystem state by removing a file. However, the file is a temporary lockfile (`/tmp/service.lock`) that was left behind from a previous crash. Removing it allows the service to restart normally without affecting any persistent data or configuration.

## Remediation

**Action Executed:** `fix_service1`  
**Command:** `rm -f /tmp/service.lock`

### Remediation Output
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

## Verification

**Post-Fix Service Status:**
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "200",
    "healthy": true
  }
}
```

✅ Service1 is now returning HTTP 200 with healthy status.

## Summary

Successfully resolved stale lockfile issue on service1 by:
1. Confirming HTTP 500 error via `get_all_service_status`
2. Diagnosing lockfile presence via `diagnose_service1`
3. Removing stale lockfile via `fix_service1` (MEDIUM risk, auto-approved)
4. Verifying service recovery (HTTP 200) via `get_all_service_status`

The service is now operational and returning the expected `"status": "ok"` response.

Fixes #131

---

_This PR was created by an AI assistant (OpenHands) on behalf of the repository maintainer._