### PR TITLE
Fix service2 readiness probe failure

### DIFF
--- a/incidents/2026-03-02-service2-readiness-probe-failure.md
+++ b/incidents/2026-03-02-service2-readiness-probe-failure.md
@@ -1,0 +1,90 @@
+# Incident Report: Service2 Readiness Probe Failure
+
+**Date**: 2026-03-02  
+**Service**: service2  
+**Endpoint**: `/service2`  
+**Issue**: #56  
+
+## Skill Used
+`readiness-probe-fail` - Resolve readiness probe failures when startup appears successful but health checks fail.
+
+## Diagnosis
+
+### Initial Status Check
+```json
+{
+  "service2": {
+    "path": "/service2",
+    "http_code": "500",
+    "healthy": false
+  }
+}
+```
+
+### Root Cause Analysis
+```json
+{
+  "service": "service2",
+  "scenario": "readiness_probe_fail",
+  "http_status": "500",
+  "healthy": false,
+  "ready_flag_exists": false,
+  "diagnosis": "Ready flag missing - service not ready",
+  "recommended_action": "fix_service2"
+}
+```
+
+**Root Cause**: The readiness flag file `/tmp/ready.flag` was missing, causing the service to return HTTP 500 "Not Ready" responses.
+
+## Risk Assessment
+
+| Action | Risk | Rationale |
+|--------|------|-----------|
+| `get_all_service_status` | LOW | Read-only health check |
+| `diagnose_service2` | LOW | Read-only diagnostic check |
+| `fix_service2` (touch /tmp/ready.flag) | LOW | Creates a flag file only, non-destructive |
+
+## Remediation
+
+Executed `fix_service2` to create the readiness flag:
+```json
+{
+  "service": "service2",
+  "action": "touch /tmp/ready.flag",
+  "risk_level": "LOW",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "touch_returncode": 0,
+  "touch_error": null
+}
+```
+
+## Verification
+
+### Post-Fix Status Check
+```json
+{
+  "service2": {
+    "path": "/service2",
+    "http_code": "200",
+    "healthy": true
+  }
+}
+```
+
+**Result**: Service2 is now returning HTTP 200 with healthy status.
+
+## Timeline
+
+1. **Detection**: Issue #56 reported service2 not working
+2. **Diagnosis**: Identified missing readiness flag file
+3. **Remediation**: Created `/tmp/ready.flag` using MCP tool
+4. **Verification**: Confirmed HTTP 200 response
+
+## Prevention
+
+Consider implementing:
+- Automated readiness flag creation during deployment
+- Alerting for readiness probe failures
+- Health check monitoring with auto-remediation


### PR DESCRIPTION
## Summary
Resolves the incident where service2 was returning HTTP 500 due to a missing readiness flag file.

Fixes #56

## Skill Used
`readiness-probe-fail` - Resolve readiness probe failures when startup appears successful but health checks fail.

## Diagnosis
Service2 was failing readiness checks because `/tmp/ready.flag` was missing:
```json
{
  "service": "service2",
  "scenario": "readiness_probe_fail",
  "http_status": "500",
  "healthy": false,
  "ready_flag_exists": false,
  "diagnosis": "Ready flag missing - service not ready"
}
```

## Remediation
Created the readiness flag using the `fix_service2` MCP tool:
```json
{
  "service": "service2",
  "action": "touch /tmp/ready.flag",
  "risk_level": "LOW",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true
}
```

## Verification
Service2 is now healthy:
```json
{
  "service2": {
    "path": "/service2",
    "http_code": "200",
    "healthy": true
  }
}
```

## Risk Assessment
| Action | Risk | Rationale |
|--------|------|-----------|
| `get_all_service_status` | LOW | Read-only health check |
| `diagnose_service2` | LOW | Read-only diagnostic check |
| `fix_service2` | LOW | Creates a flag file only |

## Changes
- Added incident report documenting the diagnosis and remediation in `incidents/2026-03-02-service2-readiness-probe-failure.md`