### PR TITLE
Fix #58: Service3 Configuration Error - bad-env-config remediation

### DIFF
--- a/incidents/issue-58-service3-env-config.md
+++ b/incidents/issue-58-service3-env-config.md
@@ -1,0 +1,62 @@
+# Incident Report: Service3 Configuration Error
+
+**Issue**: #58  
+**Service**: service3  
+**Endpoint**: `/service3`  
+**Date**: 2026-03-02  
+**Skill Used**: `bad-env-config`
+
+## Summary
+
+Service3 was returning HTTP 500 due to missing `REQUIRED_API_KEY` environment variable.
+
+## Diagnosis
+
+Using MCP diagnostic tools:
+
+| Step | Tool | Result |
+|------|------|--------|
+| 1 | `get_all_service_status` | service3 returning HTTP 500 |
+| 2 | `diagnose_service3` | Confirmed `REQUIRED_API_KEY` not set |
+
+```json
+{
+  "service": "service3",
+  "scenario": "bad_env_config",
+  "http_status": "500",
+  "healthy": false,
+  "required_api_key_set": false,
+  "diagnosis": "REQUIRED_API_KEY not set",
+  "recommended_action": "fix_service3"
+}
+```
+
+## Risk Assessment
+
+| Action | Risk Level | Justification |
+|--------|------------|---------------|
+| `get_all_service_status` | LOW | Read-only health check |
+| `diagnose_service3` | LOW | Read-only diagnosis |
+| `fix_service3` | MEDIUM | Container restart required with env var |
+
+## Remediation
+
+Called `fix_service3` which returned instructions for container restart:
+
+```bash
+docker rm -f openhands-gepa-demo && docker run -d -p 15000:5000 -e REQUIRED_API_KEY=secret --name openhands-gepa-demo openhands-gepa-sre-target:latest
+```
+
+**Note**: This fix requires manual intervention as it involves restarting the container with the correct environment variable.
+
+## Prevention
+
+Added integration tests for the `bad_env_config` scenario to verify:
+1. Service returns HTTP 500 when `REQUIRED_API_KEY` is missing
+2. Service returns HTTP 200 when `REQUIRED_API_KEY` is properly set
+
+## Verification
+
+After remediation is applied:
+- Service3 should return HTTP 200
+- `/service3` endpoint should respond with `{"status": "ok", "scenario": "bad_env_config"}`

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -122,6 +122,45 @@ class TargetServiceIntegrationTests(unittest.TestCase):
         finally:
             self._stop_container(name)
 
+    def _start_container_with_env(self, scenario: str, env_vars: dict[str, str] | None = None) -> str:
+        """Start a container with optional extra environment variables."""
+        name = f"openhands-gepa-it-{scenario}-{uuid.uuid4().hex[:6]}"
+        cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            name,
+            "-e",
+            f"SCENARIO={scenario}",
+        ]
+        if env_vars:
+            for key, value in env_vars.items():
+                cmd.extend(["-e", f"{key}={value}"])
+        cmd.append(IMAGE)
+        self._run(cmd)
+        self._wait_for_service(name)
+        return name
+
+    def test_bad_env_config_returns_500_without_api_key(self) -> None:
+        """Test that service3 (bad_env_config) returns 500 when REQUIRED_API_KEY is missing."""
+        name = self._start_container("bad_env_config")
+        try:
+            status = self._container_http_status(name)
+            self.assertEqual(status, "500")
+        finally:
+            self._stop_container(name)
+
+    def test_bad_env_config_returns_200_with_api_key(self) -> None:
+        """Test that service3 (bad_env_config) returns 200 when REQUIRED_API_KEY is set."""
+        name = self._start_container_with_env("bad_env_config", {"REQUIRED_API_KEY": "test-secret"})
+        try:
+            status = self._container_http_status(name)
+            self.assertEqual(status, "200")
+        finally:
+            self._stop_container(name)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #58 - Service3 Configuration Error where `REQUIRED_API_KEY` environment variable was not set.

## Skill Used

`bad-env-config` - Handle service failures caused by missing or invalid required environment variables.

## Diagnosis

| Step | Tool | Result |
|------|------|--------|
| 1 | `get_all_service_status` | service3 returning HTTP 500 |
| 2 | `diagnose_service3` | Confirmed `REQUIRED_API_KEY` not set |
| 3 | `fix_service3` | Returned container restart instructions |

## Risk Assessment

| Action | Risk Level | Justification |
|--------|------------|---------------|
| `get_all_service_status` | LOW | Read-only health check |
| `diagnose_service3` | LOW | Read-only diagnosis |
| `fix_service3` | MEDIUM | Container restart required with env var |

## Remediation

The `fix_service3` tool returned instructions for container restart with the required environment variable:

```bash
docker rm -f openhands-gepa-demo && docker run -d -p 15000:5000 -e REQUIRED_API_KEY=secret --name openhands-gepa-demo openhands-gepa-sre-target:latest
```

**Note**: This fix requires manual intervention as it involves restarting the container with the correct environment variable.

## Changes

- **tests/test_integration.py**: Added integration tests for `bad_env_config` scenario
  - `test_bad_env_config_returns_500_without_api_key` - verifies HTTP 500 when env var is missing
  - `test_bad_env_config_returns_200_with_api_key` - verifies HTTP 200 when env var is set
  - Added `_start_container_with_env` helper method for env var support

- **incidents/issue-58-service3-env-config.md**: Created incident report documenting diagnosis and remediation

## Verification

After remediation is applied:
- Service3 should return HTTP 200
- `/service3` endpoint should respond with `{"status": "ok", "scenario": "bad_env_config"}`