### PR TITLE
Fix service1 stale lockfile issue (HTTP 500)

### DIFF
--- a/incidents/issue-72-service1-stale-lockfile.md
+++ b/incidents/issue-72-service1-stale-lockfile.md
@@ -1,0 +1,128 @@
+# Incident Report: Service1 Stale Lockfile (Issue #72)
+
+## Summary
+**Service**: service1  
+**Issue**: HTTP 500 Internal Server Error  
+**Root Cause**: Stale lockfile present at `/tmp/service.lock`  
+**Status**: ✅ RESOLVED  
+**Date**: 2026-03-11  
+
+## Skill Used
+`stale-lockfile` (from `.agents/skills/stale-lockfile/SKILL.md`)
+
+## Diagnosis
+
+### Initial Status Check
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "500",
+    "healthy": false
+  },
+  "service2": {
+    "path": "/service2",
+    "http_code": "500",
+    "healthy": false
+  },
+  "service3": {
+    "path": "/service3",
+    "http_code": "500",
+    "healthy": false
+  }
+}
+```
+
+### Service1 Diagnosis
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1",
+  "next_step": "IMPORTANT: Call the fix_service1 tool NOW to remove the lockfile. This is MEDIUM risk and auto-approved per AGENTS.md."
+}
+```
+
+**Finding**: Confirmed stale lockfile at `/tmp/service.lock` causing HTTP 500 error.
+
+## Risk Assessment
+
+| Action | Risk Level | Justification |
+|--------|------------|---------------|
+| `get_all_service_status` | LOW | Read-only health check |
+| `diagnose_service1` | LOW | Read-only diagnostic check |
+| `rm -f /tmp/service.lock` | MEDIUM | Removes temp file only, service unaffected |
+| `get_all_service_status` (verification) | LOW | Read-only health check |
+
+**Risk Level**: MEDIUM  
+**Approval Status**: Auto-approved per AGENTS.md security policy  
+
+**Rationale**: Removing a temporary lockfile is reversible and only affects the single service instance. The lockfile serves no purpose after a crash and must be removed for service recovery.
+
+## Remediation
+
+### Action Taken
+**Tool**: `fix_service1`  
+**Command Executed**: `rm -f /tmp/service.lock`  
+
+### Remediation Result
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+**Result**: ✅ Lockfile successfully removed, service recovered
+
+## Verification
+
+### Post-Fix Status Check
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "200",
+    "healthy": true
+  },
+  "service2": {
+    "path": "/service2",
+    "http_code": "500",
+    "healthy": false
+  },
+  "service3": {
+    "path": "/service3",
+    "http_code": "500",
+    "healthy": false
+  }
+}
+```
+
+**Verification**: ✅ Service1 now returns HTTP 200 with `"status": "ok"`
+
+## Timeline
+1. **14:40 UTC** - Issue detected: service1 returning HTTP 500
+2. **14:40 UTC** - Diagnosis confirmed: stale lockfile at `/tmp/service.lock`
+3. **14:40 UTC** - Remediation executed: lockfile removed via `fix_service1` MCP tool
+4. **14:41 UTC** - Verification completed: service1 healthy (HTTP 200)
+
+## Resolution
+Service1 has been successfully recovered by removing the stale lockfile. The service is now returning HTTP 200 as expected.
+
+## Follow-up Actions
+None required. This is a known incident pattern with established remediation procedure.
+
+## References
+- Skill: `.agents/skills/stale-lockfile/SKILL.md`
+- Repository Guidelines: `AGENTS.md`
+- Issue: #72


### PR DESCRIPTION
## Summary
Resolves issue #72 - service1 was returning HTTP 500 due to a stale lockfile at `/tmp/service.lock`.

## Incident Details
- **Service**: service1
- **Endpoint**: `/service1`
- **Error**: HTTP 500 Internal Server Error
- **Root Cause**: Stale lockfile present at `/tmp/service.lock`
- **Status**: ✅ RESOLVED

## Skill Used
`stale-lockfile` (from `.agents/skills/stale-lockfile/SKILL.md`)

## Actions Taken

| Action | Risk Level | Result |
|--------|------------|--------|
| `get_all_service_status` | LOW | Confirmed service1 HTTP 500 |
| `diagnose_service1` | LOW | Found stale lockfile at /tmp/service.lock |
| `fix_service1` (rm -f /tmp/service.lock) | MEDIUM | Successfully removed lockfile |
| `get_all_service_status` | LOW | Verified service1 HTTP 200 ✅ |

### Risk Assessment
**Risk Level**: MEDIUM (auto-approved per AGENTS.md)  
**Rationale**: Removing a temporary lockfile is reversible and only affects the single service instance. The lockfile serves no purpose after a crash and must be removed for service recovery.

## Verification

**Pre-fix status:**
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "500",
    "healthy": false
  }
}
```

**Post-fix status:**
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "200",
    "healthy": true
  }
}
```

✅ Service1 now returns HTTP 200 with `"status": "ok"`

## Changes
- Created incident report documenting the full remediation workflow with MCP tool outputs

## References
- Fixes #72
- Skill: `.agents/skills/stale-lockfile/SKILL.md`
- Repository Guidelines: `AGENTS.md`