### PR TITLE
fix: resolve stale lockfile on service1 (fixes #79)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,14 +1,65 @@
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 import time
 import unittest
 import uuid
 from pathlib import Path
 
+# Allow importing the target_service package without Docker
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 ROOT = Path(__file__).resolve().parents[1]
 IMAGE = "openhands-gepa-sre-target:latest"
+LOCKFILE = "/tmp/service.lock"
+
+
+class StaleLockfileUnitTests(unittest.TestCase):
+    """Unit tests for the stale lockfile scenario using Flask test client.
+
+    These tests run without Docker and directly exercise the Flask app logic.
+    """
+
+    def setUp(self) -> None:
+        if os.path.exists(LOCKFILE):
+            os.remove(LOCKFILE)
+        from target_service.app import app
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+
+    def tearDown(self) -> None:
+        if os.path.exists(LOCKFILE):
+            os.remove(LOCKFILE)
+
+    def test_service1_returns_500_when_lockfile_present(self) -> None:
+        Path(LOCKFILE).touch()
+        resp = self.client.get("/service1", headers={"Accept": "application/json"})
+        self.assertEqual(resp.status_code, 500)
+        data = resp.get_json()
+        self.assertEqual(data["status"], "error")
+        self.assertIn("stale lockfile", data["reason"])
+
+    def test_service1_returns_200_after_lockfile_removed(self) -> None:
+        Path(LOCKFILE).touch()
+        resp_before = self.client.get("/service1", headers={"Accept": "application/json"})
+        self.assertEqual(resp_before.status_code, 500)
+
+        # Simulate remediation: remove the stale lockfile
+        os.remove(LOCKFILE)
+
+        resp_after = self.client.get("/service1", headers={"Accept": "application/json"})
+        self.assertEqual(resp_after.status_code, 200)
+        data = resp_after.get_json()
+        self.assertEqual(data["status"], "ok")
+
+    def test_service1_returns_200_without_lockfile(self) -> None:
+        self.assertFalse(os.path.exists(LOCKFILE))
+        resp = self.client.get("/service1", headers={"Accept": "application/json"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertEqual(data["status"], "ok")
 
 
 class TargetServiceIntegrationTests(unittest.TestCase):


### PR DESCRIPTION
## Incident Report — Stale Lockfile on service1

Fixes #79

---

## Skill Used
`stale-lockfile` (`.agents/skills/stale-lockfile/SKILL.md`)

---

## Diagnosis

| Step | Tool | Result |
|------|------|--------|
| Initial status check | `get_all_service_status` | service1 `http_code: "500"`, unhealthy |
| Root cause confirmation | `diagnose_service1` | `lock_file_exists: true` at `/tmp/service.lock` |

**Raw tool output — `get_all_service_status` (before fix):**
```json
{
  "service1": { "path": "/service1", "http_code": "500", "healthy": false },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

**Raw tool output — `diagnose_service1`:**
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

---

## Risk Assessment

| Action | Risk | Rationale |
|--------|------|-----------|
| `get_all_service_status` | LOW | Read-only health check |
| `diagnose_service1` | LOW | Read-only diagnosis |
| `fix_service1` (removes `/tmp/service.lock`) | MEDIUM | Removes temp file only; auto-approved per AGENTS.md |
| `get_all_service_status` (verification) | LOW | Read-only health check |

---

## Remediation

**Raw tool output — `fix_service1`:**
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

---

## Verification

**Raw tool output — `get_all_service_status` (after fix):**
```json
{
  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

All services healthy. service1 restored to HTTP 200.

---

## Code Changes

Added `StaleLockfileUnitTests` class to `tests/test_integration.py` with 3 unit tests that use Flask's test client (no Docker required):

- `test_service1_returns_500_when_lockfile_present` — verifies the error condition
- `test_service1_returns_200_after_lockfile_removed` — verifies the recovery path
- `test_service1_returns_200_without_lockfile` — verifies the healthy baseline

All 3 tests pass ✅
