### PR TITLE
fix: resolve stale lockfile on service1 (fixes #81)

### DIFF
--- a/tests/test_service1_stale_lockfile.py
+++ b/tests/test_service1_stale_lockfile.py
@@ -1,0 +1,72 @@
+"""Unit tests for service1 stale-lockfile scenario (issue #81).
+
+These tests use Flask's built-in test client and do not require Docker.
+They verify that:
+  - service1 returns HTTP 500 when /tmp/service.lock exists
+  - service1 returns HTTP 200 once the lockfile is removed
+"""
+from __future__ import annotations
+
+import sys
+import os
+import unittest
+import tempfile
+from pathlib import Path
+
+# Ensure target_service is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "target_service"))
+
+import app as service_app
+
+
+class TestService1StaleLockfile(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = service_app.app.test_client()
+        # Patch LOCKFILE to a temp path so tests are isolated from each other
+        self._tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".lock")
+        self._tmp.close()
+        self._original_lockfile = service_app.LOCKFILE
+        service_app.LOCKFILE = self._tmp.name
+
+    def tearDown(self) -> None:
+        service_app.LOCKFILE = self._original_lockfile
+        try:
+            os.unlink(self._tmp.name)
+        except FileNotFoundError:
+            pass
+
+    def test_returns_500_when_lockfile_exists(self) -> None:
+        """service1 must return HTTP 500 when the lockfile is present."""
+        # Lockfile was created in setUp — it exists
+        response = self.client.get("/service1", headers={"User-Agent": "curl/7.0"})
+        self.assertEqual(response.status_code, 500)
+        data = response.get_json()
+        self.assertEqual(data["status"], "error")
+        self.assertIn("stale lockfile", data["reason"])
+
+    def test_returns_200_after_lockfile_removed(self) -> None:
+        """service1 must return HTTP 200 once the stale lockfile has been removed."""
+        os.unlink(self._tmp.name)  # simulate fix: remove the lockfile
+
+        response = self.client.get("/service1", headers={"User-Agent": "curl/7.0"})
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data["status"], "ok")
+
+    def test_lockfile_removal_recovers_service(self) -> None:
+        """End-to-end: 500 before fix, 200 after — mirrors the incident remediation."""
+        # Before fix
+        before = self.client.get("/service1", headers={"User-Agent": "curl/7.0"})
+        self.assertEqual(before.status_code, 500)
+
+        # Apply fix: remove stale lockfile
+        os.unlink(self._tmp.name)
+
+        # After fix
+        after = self.client.get("/service1", headers={"User-Agent": "curl/7.0"})
+        self.assertEqual(after.status_code, 200)
+        self.assertEqual(after.get_json()["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Skill Used
`stale-lockfile` — `.agents/skills/stale-lockfile/SKILL.md`

Fixes #81

---

## Incident Summary

**Service:** service1 (health-api) — `/service1`  
**Detected:** 2026-03-16T15:14:59  
**Symptom:** HTTP 500 — `"stale lockfile present at /tmp/service.lock"`

---

## Diagnosis

MCP tool outputs (raw JSON):

**Step 1 — `get_all_service_status` (before fix):**
```json
{
  "service1": { "path": "/service1", "http_code": "500", "healthy": false },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

**Step 2 — `diagnose_service1`:**
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

---

## Risk Assessment

| Action | Risk | Rationale |
|--------|------|-----------|
| `get_all_service_status` | LOW | Read-only health check |
| `diagnose_service1` | LOW | Read-only lockfile existence check |
| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes temp lockfile only; auto-approved per AGENTS.md |
| `get_all_service_status` (verify) | LOW | Read-only health check |

---

## Remediation

**Step 3 — `fix_service1`:**
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

---

## Verification

**Step 4 — `get_all_service_status` (after fix):**
```json
{
  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

All services healthy. ✅

---

## Tests Added

`tests/test_service1_stale_lockfile.py` — unit tests using Flask's test client (no Docker required):

- `test_returns_500_when_lockfile_exists` — verifies HTTP 500 with lockfile present
- `test_returns_200_after_lockfile_removed` — verifies HTTP 200 after lockfile removal  
- `test_lockfile_removal_recovers_service` — end-to-end: 500 → remove lockfile → 200

All 3 tests pass. ✅
