### PR TITLE
fix: resolve stale lockfile causing service1 HTTP 500 (fixes #91)

### DIFF
--- a/incidents/issue-91-stale-lockfile.md
+++ b/incidents/issue-91-stale-lockfile.md
@@ -1,0 +1,95 @@
+# Incident Report: Issue #91 — service1 Stale Lockfile (HTTP 500)
+
+**Date**: 2026-03-18  
+**Skill Used**: `stale-lockfile` (`.agents/skills/stale-lockfile/`)  
+**Issue**: #91
+
+---
+
+## Diagnosis
+
+`get_all_service_status` confirmed service1 was returning HTTP 500. `diagnose_service1` confirmed the root cause: a stale lockfile at `/tmp/service.lock` left behind from a previous deployment crash.
+
+**Tool outputs:**
+
+`get_all_service_status` (before fix):
+```json
+{
+  "service1": { "path": "/service1", "http_code": "500", "healthy": false },
+  "service2": { "path": "/service2", "http_code": "500", "healthy": false },
+  "service3": { "path": "/service3", "http_code": "500", "healthy": false }
+}
+```
+
+`diagnose_service1`:
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1"
+}
+```
+
+---
+
+## Risk Assessment
+
+| Action | Risk Level | Rationale |
+|--------|------------|-----------|
+| `get_all_service_status` | LOW | Read-only health check |
+| `diagnose_service1` | LOW | Read-only diagnosis |
+| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes temp lockfile only; auto-approved per AGENTS.md |
+| `get_all_service_status` (verification) | LOW | Read-only health check |
+
+---
+
+## Remediation
+
+Called `fix_service1`, which executed `rm -f /tmp/service.lock` on the server.
+
+**Tool output:**
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+---
+
+## Verification
+
+`get_all_service_status` (after fix):
+```json
+{
+  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
+  "service2": { "path": "/service2", "http_code": "500", "healthy": false },
+  "service3": { "path": "/service3", "http_code": "500", "healthy": false }
+}
+```
+
+✅ service1 is healthy — returning HTTP 200 with `"status": "ok"`.
+
+---
+
+## Root Cause
+
+The service checks for the presence of `/tmp/service.lock` on startup and at each request. After a crash during the previous deployment, the lockfile was not cleaned up, causing every subsequent request to return HTTP 500.
+
+## Resolution
+
+Removed the stale lockfile with `rm -f /tmp/service.lock` (MEDIUM risk, auto-approved).
+
+## Prevention
+
+Consider adding lockfile cleanup to the service's shutdown handler and/or deployment pipeline teardown step to prevent stale lockfiles from persisting across restarts.


### PR DESCRIPTION
## Skill Used
`stale-lockfile` — `.agents/skills/stale-lockfile/`

Fixes #91

---

## Diagnosis

`diagnose_service1` confirmed a stale lockfile at `/tmp/service.lock` was causing service1 to return HTTP 500 after a deployment crash.

**`get_all_service_status` (before fix):**
```json
{
  "service1": { "path": "/service1", "http_code": "500", "healthy": false }
}
```

**`diagnose_service1`:**
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

---

## Risk Assessment

| Action | Risk Level | Rationale |
|--------|------------|-----------|
| `get_all_service_status` | LOW | Read-only health check |
| `diagnose_service1` | LOW | Read-only diagnosis |
| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes temp lockfile only; auto-approved per AGENTS.md |
| `get_all_service_status` (verification) | LOW | Read-only health check |

---

## Remediation

Called `fix_service1` to remove `/tmp/service.lock`:

```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

---

## Verification

**`get_all_service_status` (after fix):**
```json
{
  "service1": { "path": "/service1", "http_code": "200", "healthy": true }
}
```

✅ service1 now returns HTTP 200 with `"status": "ok"`.

---

## Changes

- Added `incidents/issue-91-stale-lockfile.md` with full incident report including all tool outputs and risk annotations.
