### PR TITLE
[KAN-6] Fix service1 HTTP 500 caused by stale lockfile

### DIFF
--- a/incidents/KAN-6-service1-stale-lockfile.md
+++ b/incidents/KAN-6-service1-stale-lockfile.md
@@ -1,0 +1,94 @@
+# Incident Report: KAN-6 — service1 HTTP 500 (Stale Lockfile)
+
+**Date**: 2026-03-19  
+**Issue**: KAN-6  
+**Skill Used**: `stale-lockfile` (`.agents/skills/stale-lockfile/`)  
+**Severity**: P2 — Service Unavailable (HTTP 500)  
+**Resolution Time**: < 5 minutes
+
+---
+
+## Diagnosis
+
+`diagnose_service1` output:
+
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1"
+}
+```
+
+**Root Cause**: A stale lockfile at `/tmp/service.lock` was left behind (likely from a previous crash or unclean shutdown). The service checks for this lockfile on startup/request handling and returns HTTP 500 when it exists, to prevent concurrent runs. Since the previous process no longer holds the lock, it is safe to remove.
+
+---
+
+## Risk Assessment
+
+| Action | Risk Level | Rationale |
+|--------|------------|-----------|
+| `diagnose_service1` | LOW | Read-only health check — no state changes |
+| `fix_service1` → `rm -f /tmp/service.lock` | MEDIUM | Removes a temp lockfile only; no data loss; auto-approved per AGENTS.md |
+| `get_all_service_status` | LOW | Read-only verification — no state changes |
+
+---
+
+## Remediation
+
+`fix_service1` output:
+
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+The stale lockfile `/tmp/service.lock` was removed successfully (`rm_returncode: 0`).
+
+---
+
+## Verification
+
+`get_all_service_status` output after fix:
+
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "200",
+    "healthy": true
+  },
+  "service2": {
+    "path": "/service2",
+    "http_code": "500",
+    "healthy": false
+  },
+  "service3": {
+    "path": "/service3",
+    "http_code": "500",
+    "healthy": false
+  }
+}
+```
+
+✅ **service1 is now returning HTTP 200 and is healthy.**
+
+---
+
+## Prevention Recommendations
+
+1. Implement a lockfile cleanup routine in the service's startup script that checks if the lock-holding PID is still alive before failing.
+2. Add a liveness/readiness probe in the deployment manifest that removes stale lockfiles on pod restart.
+3. Consider using advisory locking mechanisms (e.g., `flock`) that are automatically released by the OS when the process terminates.


### PR DESCRIPTION
## Skill Used
`stale-lockfile` — `.agents/skills/stale-lockfile/`

## Summary
service1 was returning HTTP 500 due to a stale lockfile at `/tmp/service.lock` left behind from a previous crash. The lockfile was removed, restoring service1 to healthy (HTTP 200).

## Diagnosis

`diagnose_service1` output:
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

**Root Cause**: A stale `/tmp/service.lock` was blocking service1. The service returns HTTP 500 when this lockfile exists to prevent concurrent runs — but the original process was no longer running, making the lock stale and safe to remove.

## Risk Assessment

| Action | Risk Level | Rationale |
|--------|------------|-----------|
| `diagnose_service1` | LOW | Read-only health check |
| `fix_service1` → `rm -f /tmp/service.lock` | MEDIUM | Removes temp lockfile only; no data loss; auto-approved per AGENTS.md |
| `get_all_service_status` | LOW | Read-only verification |

## Remediation

`fix_service1` output:
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

## Verification

`get_all_service_status` after fix:
```json
{
  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
  "service2": { "path": "/service2", "http_code": "500", "healthy": false },
  "service3": { "path": "/service3", "http_code": "500", "healthy": false }
}
```

✅ **service1 is now returning HTTP 200 and is healthy.**

## Changes
- Added `incidents/KAN-6-service1-stale-lockfile.md` with full incident report

## Prevention Recommendations
1. Add startup script logic to verify the lock-holding PID is alive before treating the lockfile as valid.
2. Use OS-level advisory locking (`flock`) that is auto-released on process termination.
3. Add a liveness probe to clean up stale lockfiles on pod restart.

Closes KAN-6

@rajshah4 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/85f87344e2dc49d985f016a1b4d07c6f)