### PR TITLE
docs: enforce verbose PR descriptions in agent skills

### DIFF
--- a/.agents/skills/readiness-probe-fail/SKILL.md
+++ b/.agents/skills/readiness-probe-fail/SKILL.md
@@ -24,7 +24,12 @@ The MCP tools `get_all_service_status`, `diagnose_service2`, and `fix_service2` 
 2. **Call `diagnose_service2`** — confirm ready flag missing. Paste the JSON.
 3. **Call `fix_service2`** — creates the readiness flag. Paste the JSON. Must show `"fixed": true`.
 4. **Call `get_all_service_status`** — confirm service2 HTTP 200. Paste the JSON.
-5. Create a PR with the incident report including the tool outputs above.
+5. Create a PR. The PR body MUST follow the **Incident Response Format** defined in `AGENTS.md`. Include:
+    - Skill Used
+    - Diagnosis (with tool outputs)
+    - Risk Assessment
+    - Remediation (with tool outputs)
+    - Verification (with tool outputs)
 
 ## Success Criteria
 - `fix_service2` returns `"fixed": true` and `"post_http_status": "200"`

--- a/.agents/skills/stale-lockfile/SKILL.md
+++ b/.agents/skills/stale-lockfile/SKILL.md
@@ -24,7 +24,12 @@ The MCP tools `get_all_service_status`, `diagnose_service1`, and `fix_service1` 
 2. **Call `diagnose_service1`** — confirm lockfile exists. Paste the JSON.
 3. **Call `fix_service1`** — removes the lockfile. Paste the JSON. Must show `"fixed": true`.
 4. **Call `get_all_service_status`** — confirm service1 HTTP 200. Paste the JSON.
-5. Create a PR with the incident report including the tool outputs above.
+5. Create a PR. The PR body MUST follow the **Incident Response Format** defined in `AGENTS.md`. Include:
+    - Skill Used
+    - Diagnosis (with tool outputs)
+    - Risk Assessment
+    - Remediation (with tool outputs)
+    - Verification (with tool outputs)
 
 ## Success Criteria
 - `fix_service1` returns `"fixed": true` and `"post_http_status": "200"`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ Only after step 4 confirms the fix, create a PR documenting what happened.
 
 ## Incident Response Format
 
-When responding to incidents, use this structure:
+When responding to incidents AND when creating Pull Requests, use this structure:
 
 ```
 ## Skill Used


### PR DESCRIPTION
Updates AGENTS.md and skill definitions to mandate the Incident Response Format for PR descriptions, ensuring better documentation of automated fixes.