### PR TITLE
Fix issue #119: Remove stale lockfile from service1

### DIFF
--- a/INCIDENT_REPORT_119.md
+++ b/INCIDENT_REPORT_119.md
@@ -1,0 +1,93 @@
+# Incident Report: Issue #119 - Service1 Stale Lockfile
+
+## Skill Used
+**stale-lockfile** (`.agents/skills/stale-lockfile/SKILL.md`)
+
+## Diagnosis
+
+Service1 was returning HTTP 500 Internal Server Error due to a stale lockfile remaining after a previous crash.
+
+### Initial Status Check
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "500",
+    "healthy": false
+  }
+}
+```
+
+### Diagnostic Results
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1"
+}
+```
+
+**Root Cause**: Stale lockfile present at `/tmp/service.lock` preventing service startup.
+
+## Risk Assessment
+
+| Action | Risk Level | Justification |
+|--------|------------|---------------|
+| `rm -f /tmp/service.lock` | **MEDIUM** | Removes temporary lockfile only. Service unaffected. Auto-approved per AGENTS.md policy. |
+
+**Rationale**: The lockfile is a temporary file used for process synchronization. Removing it is safe because:
+- It's in `/tmp/` (temporary directory)
+- The file is stale (from a crashed process)
+- The service cannot start while the file exists
+- Removal is reversible (service recreates it when needed)
+
+## Remediation
+
+**Action Taken**: Executed `fix_service1` MCP tool to remove stale lockfile.
+
+### Remediation Output
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+**Result**: ✅ Successfully removed lockfile with return code 0 (no errors).
+
+## Verification
+
+### Post-Fix Status Check
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "200",
+    "healthy": true
+  }
+}
+```
+
+**Verification Results**:
+- ✅ Service1 now returns HTTP 200
+- ✅ Health check passes with `"healthy": true`
+- ✅ Service responding correctly to requests
+- ✅ No errors in the remediation process
+
+## Summary
+
+Successfully resolved HTTP 500 error on service1 by removing stale lockfile at `/tmp/service.lock`. Service is now healthy and returning expected HTTP 200 responses. Remediation was performed using MCP tools with MEDIUM risk level (auto-approved).
+
+**Time to Resolution**: < 1 minute  
+**Service Downtime**: Minimal (lockfile removal is instantaneous)  
+**Impact**: Service restored to full health


### PR DESCRIPTION
## Issue
Fixes #119 - Service1 returning HTTP 500 due to stale lockfile

## Skill Used
**stale-lockfile** (`.agents/skills/stale-lockfile/SKILL.md`)

## Diagnosis

Service1 was returning HTTP 500 Internal Server Error due to a stale lockfile remaining at `/tmp/service.lock` after a previous crash.

### Initial Status
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "500",
    "healthy": false
  }
}
```

### Diagnostic Output
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

## Risk Assessment

| Action | Risk Level | Justification |
|--------|------------|---------------|
| `rm -f /tmp/service.lock` | **MEDIUM** | Removes temporary lockfile only. Service unaffected. Auto-approved per AGENTS.md policy. |

The lockfile is a temporary file in `/tmp/` left by a crashed process. Removing it is safe and necessary for service recovery.

## Remediation

Executed `fix_service1` MCP tool to remove the stale lockfile.

### Remediation Output
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

## Verification

### Post-Fix Status
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "200",
    "healthy": true
  }
}
```

**Results**:
- ✅ Service1 now returns HTTP 200
- ✅ Health check passes
- ✅ Service fully restored
- ✅ No remediation errors

## Testing

Integration tests already exist for this scenario in `tests/test_integration.py::test_stale_lockfile_recovers_500_to_200` which validates:
1. Service returns HTTP 500 with stale lockfile present
2. Lockfile removal recovers service to HTTP 200

## Documentation

Added `INCIDENT_REPORT_119.md` with complete incident details for audit trail and future reference.

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@rajshah4 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2b25855c-1cc1-43d3-a828-429f10f7e7b0)