### PR TITLE
Fix issue #134: Service1 stale lockfile incident resolution

### DIFF
--- a/INCIDENT-134.md
+++ b/INCIDENT-134.md
@@ -1,0 +1,116 @@
+# Incident Report: Issue #134 - Service1 Stale Lockfile
+
+## Skill Used
+`stale-lockfile` - Stale lockfile remediation runbook from `.agents/skills/stale-lockfile/`
+
+## Diagnosis
+
+### Initial Status Check
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "200",
+    "healthy": true
+  },
+  "service2": {
+    "path": "/service2",
+    "http_code": "200",
+    "healthy": true
+  },
+  "service3": {
+    "path": "/service3",
+    "http_code": "200",
+    "healthy": true
+  }
+}
+```
+
+### Service1 Diagnosis
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "200",
+  "healthy": true,
+  "lock_file_exists": false,
+  "diagnosis": "No lockfile found",
+  "recommended_action": "No action needed",
+  "next_step": "Service is healthy."
+}
+```
+
+**Finding**: Service1 had already recovered by the time of investigation. The stale lockfile at `/tmp/service.lock` was no longer present, and the service was returning HTTP 200.
+
+## Risk Assessment
+
+| Action | Risk Level | Rationale |
+|--------|------------|-----------|
+| `get_all_service_status` | LOW | Read-only health check via HTTP |
+| `diagnose_service1` | LOW | Read-only check for lockfile existence |
+| `fix_service1` | MEDIUM | Executes `rm -f /tmp/service.lock` - removes temp file only, service unaffected |
+
+**Risk Level**: MEDIUM (auto-approved per AGENTS.md policy)
+
+The `fix_service1` action removes only a temporary lockfile and does not affect service state. This is a reversible action with minimal impact.
+
+## Remediation
+
+Despite the service being healthy, the complete remediation workflow was executed to ensure consistency:
+
+### Fix Execution
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "200",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+The lockfile removal command executed successfully (`rm_returncode: 0`), though the file was already absent.
+
+## Verification
+
+### Final Status Check
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "200",
+    "healthy": true
+  },
+  "service2": {
+    "path": "/service2",
+    "http_code": "200",
+    "healthy": true
+  },
+  "service3": {
+    "path": "/service3",
+    "http_code": "200",
+    "healthy": true
+  }
+}
+```
+
+✅ **Verification successful**: Service1 is healthy and returning HTTP 200.
+
+## Summary
+
+The reported stale lockfile issue (#134) had already been resolved by the time of investigation. The service recovered either through:
+- Automatic cleanup during service restart
+- Manual intervention before this investigation
+- Self-healing mechanism
+
+The complete MCP remediation workflow was executed as per protocol to ensure proper incident handling. Service1 is confirmed healthy with no lockfile present.
+
+## Related Tests
+
+The stale lockfile scenario is covered by the existing integration test:
+- `tests/test_integration.py::TargetServiceIntegrationTests::test_stale_lockfile_recovers_500_to_200`
+
+This test verifies that removing `/tmp/service.lock` recovers service1 from HTTP 500 to HTTP 200.


### PR DESCRIPTION
## Skill Used
`stale-lockfile` - Stale lockfile remediation runbook from `.agents/skills/stale-lockfile/`

## Diagnosis

Upon investigation of issue #134, service1 had already recovered from the reported HTTP 500 error:

**Initial Status Check:**
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "200",
    "healthy": true
  }
}
```

**Service1 Diagnosis:**
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "200",
  "healthy": true,
  "lock_file_exists": false,
  "diagnosis": "No lockfile found",
  "recommended_action": "No action needed"
}
```

**Finding**: The stale lockfile at `/tmp/service.lock` was no longer present, and the service was returning HTTP 200. The service had recovered either through automatic cleanup, service restart, or previous manual intervention.

## Risk Assessment

| Action | Risk Level | Rationale |
|--------|------------|-----------|
| `get_all_service_status` | LOW | Read-only health check via HTTP |
| `diagnose_service1` | LOW | Read-only check for lockfile existence |
| `fix_service1` | MEDIUM | Executes `rm -f /tmp/service.lock` - removes temp file only, service unaffected |

**Overall Risk**: MEDIUM (auto-approved per AGENTS.md security policy)

The `fix_service1` action removes only a temporary lockfile and does not affect service state. This is a reversible action with minimal impact.

## Remediation

Despite the service being healthy, the complete MCP remediation workflow was executed to ensure protocol consistency:

**Fix Execution:**
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "200",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

The lockfile removal command executed successfully (`rm_returncode: 0`), confirming proper MCP tool operation.

## Verification

**Final Status Check:**
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "200",
    "healthy": true
  }
}
```

✅ **Verification successful**: Service1 is healthy and returning HTTP 200.

## Test Coverage

The stale lockfile scenario is covered by existing integration test:
- `tests/test_integration.py::TargetServiceIntegrationTests::test_stale_lockfile_recovers_500_to_200`

This test verifies that removing `/tmp/service.lock` recovers service1 from HTTP 500 to HTTP 200.

## Summary

The reported stale lockfile issue had already been resolved by the time of investigation. The complete MCP remediation workflow was executed as per protocol to ensure proper incident handling. Service1 is confirmed healthy with no lockfile present.

Closes #134

@rajshah4 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/426bd518-9d8d-485f-8e10-ee14aeec45d4)