### PR TITLE
Fix issue #141: Remove stale lockfile from service1

### DIFF
--- a/INCIDENT-141.md
+++ b/INCIDENT-141.md
@@ -1,0 +1,104 @@
+# Incident Report: Service1 Stale Lockfile - Issue #141
+
+## Skill Used
+`stale-lockfile` (.agents/skills/stale-lockfile/SKILL.md)
+
+## Diagnosis
+
+**Initial Status Check:**
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "500",
+    "healthy": false
+  }
+}
+```
+
+**Diagnostic Results:**
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1"
+}
+```
+
+**Root Cause:**
+- Stale lockfile present at `/tmp/service.lock`
+- Service crashed during previous deployment without cleaning up lockfile
+- Lockfile preventing service from starting properly
+- Health endpoint returning HTTP 500 Internal Server Error
+
+## Risk Assessment
+
+| Action | Risk Level | Justification |
+|--------|------------|---------------|
+| `diagnose_service1` | LOW | Read-only diagnostic check |
+| `rm -f /tmp/service.lock` | MEDIUM | Removes temporary lockfile only; auto-approved per AGENTS.md policy |
+| `get_all_service_status` | LOW | Read-only health check |
+
+**MEDIUM Risk Rationale:**
+The `fix_service1` action removes only the stale temporary lockfile at `/tmp/service.lock`. This is a safe operation because:
+- The file is in `/tmp` (temporary directory)
+- It's a lockfile used only for process coordination
+- The `-f` flag ensures no errors if file doesn't exist
+- No impact on actual service code or data
+- Operation is reversible (service will recreate lockfile if needed)
+
+## Remediation
+
+**Action Taken:**
+Executed `fix_service1` MCP tool to remove stale lockfile.
+
+**Execution Results:**
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+**Key Indicators:**
+- `fixed: true` - Operation completed successfully
+- `rm_returncode: 0` - No errors during file removal
+- `post_http_status: "200"` - Service immediately recovered
+
+## Verification
+
+**Post-Fix Status Check:**
+```json
+{
+  "service1": {
+    "path": "/service1",
+    "http_code": "200",
+    "healthy": true
+  }
+}
+```
+
+**Success Criteria Met:**
+- ✅ Service1 now returns HTTP 200
+- ✅ Health endpoint shows `"healthy": true`
+- ✅ No errors during remediation
+- ✅ Service recovered without restart
+
+## Summary
+
+Successfully resolved stale lockfile issue for service1 using the MCP `fix_service1` tool. The service is now healthy and responding correctly to health checks. No code changes were required as this was a runtime issue resolved through infrastructure automation.
+
+**Time to Resolution:** Immediate (automated remediation)
+**Services Affected:** service1 only
+**Data Loss:** None
+**Code Changes Required:** None


### PR DESCRIPTION
## Issue
Fixes #141 - Service1 returning HTTP 500 due to stale lockfile

## Skill Used
`stale-lockfile` (`.agents/skills/stale-lockfile/SKILL.md`)

## Diagnosis

**Initial Status:**
- Service1 endpoint `/service1` returning HTTP 500 Internal Server Error
- Error message: "stale lockfile present at /tmp/service.lock"
- Service was healthy before last deployment

**Diagnostic Results:**
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal"
}
```

**Root Cause:**
Service crashed during previous deployment without cleaning up lockfile at `/tmp/service.lock`, preventing subsequent startups.

## Risk Assessment

| Action | Risk Level | Justification |
|--------|------------|---------------|
| `diagnose_service1` | LOW | Read-only diagnostic check |
| `rm -f /tmp/service.lock` | MEDIUM | Removes temp lockfile only; auto-approved per AGENTS.md |
| `get_all_service_status` | LOW | Read-only health check |

The remediation action is classified as **MEDIUM risk** and is **auto-approved** per repository security policy. The lockfile is a temporary coordination file in `/tmp` with no impact on service code or data.

## Remediation

Executed `fix_service1` MCP tool to remove the stale lockfile:

```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0
}
```

## Verification

**Post-Fix Status:**
```json
{
  "service1": {
    "path": "/service1",
    "http_code": "200",
    "healthy": true
  }
}
```

**Success Criteria Met:**
- ✅ Service1 returns HTTP 200
- ✅ Health endpoint shows `healthy: true`
- ✅ No errors during remediation
- ✅ Service recovered immediately without restart

## Changes

- Added `INCIDENT-141.md` documenting the full incident response with all diagnostic outputs and verification results

## Testing

No code changes were made. This was a runtime issue resolved through infrastructure automation using MCP tools. The verification step confirms service1 is now healthy and responding correctly.


@rajshah4 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cc3d6813-e49b-4018-b8f7-0fbae1d4962f)