### PR TITLE
Fix #152: Remove stale lockfile on service1

### DIFF
--- a/incidents/152-stale-lockfile-service1.md
+++ b/incidents/152-stale-lockfile-service1.md
@@ -1,0 +1,73 @@
+# Incident #152: service1 returning HTTP 500 (stale lockfile)
+
+Fixes #152
+
+## Skill Used
+`stale-lockfile` (see `.agents/skills/stale-lockfile/SKILL.md`)
+
+## Diagnosis
+service1 `/service1` was returning HTTP 500. The runbook for stale lockfiles
+was triggered by the error message in the issue: `stale lockfile present at /tmp/service.lock`.
+
+Pre-fix status (`get_all_service_status`):
+```json
+{
+  "service1": {"path": "/service1", "http_code": "500", "healthy": false},
+  "service2": {"path": "/service2", "http_code": "200", "healthy": true},
+  "service3": {"path": "/service3", "http_code": "200", "healthy": true}
+}
+```
+
+Root cause confirmation (`diagnose_service1`):
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1"
+}
+```
+
+A previous crash left `/tmp/service.lock` on disk; on restart the service
+refused to serve traffic because it interpreted the file as another instance
+holding the lock.
+
+## Risk Assessment
+
+| Action | Risk | Rationale |
+|--------|------|-----------|
+| `get_all_service_status` | LOW | Read-only health probe. |
+| `diagnose_service1` | LOW | Read-only check for lockfile + HTTP status. |
+| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes a single temp file in `/tmp`. Reversible (the service recreates it on startup) and auto-approved per `AGENTS.md`. No data is lost. |
+
+## Remediation
+Executed `fix_service1`, which removed the stale lockfile remotely on the
+service host:
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+## Verification
+Post-fix status (`get_all_service_status`):
+```json
+{
+  "service1": {"path": "/service1", "http_code": "200", "healthy": true},
+  "service2": {"path": "/service2", "http_code": "200", "healthy": true},
+  "service3": {"path": "/service3", "http_code": "200", "healthy": true}
+}
+```
+
+service1 now returns HTTP 200 and the issue's expected behavior
+(`"status": "ok"`) is restored.


### PR DESCRIPTION
Fixes #152

## Skill Used
`stale-lockfile` (`.agents/skills/stale-lockfile/SKILL.md`) — service1 was returning HTTP 500 due to `/tmp/service.lock` left behind by a previous crash.

## Diagnosis
`get_all_service_status` (pre-fix):
```json
{
  "service1": {"path": "/service1", "http_code": "500", "healthy": false},
  "service2": {"path": "/service2", "http_code": "200", "healthy": true},
  "service3": {"path": "/service3", "http_code": "200", "healthy": true}
}
```

`diagnose_service1`:
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

## Risk Assessment

| Action | Risk | Rationale |
|--------|------|-----------|
| `get_all_service_status` | LOW | Read-only health probe |
| `diagnose_service1` | LOW | Read-only lockfile + HTTP check |
| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes a single temp file; reversible (recreated on next legitimate run); auto-approved per `AGENTS.md` |

## Remediation
Called `fix_service1`, which removed `/tmp/service.lock` on the service host:
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

## Verification
`get_all_service_status` (post-fix):
```json
{
  "service1": {"path": "/service1", "http_code": "200", "healthy": true},
  "service2": {"path": "/service2", "http_code": "200", "healthy": true},
  "service3": {"path": "/service3", "http_code": "200", "healthy": true}
}
```

service1 now returns HTTP 200, matching the expected `"status": "ok"`.

Full incident report is committed at `incidents/152-stale-lockfile-service1.md`.

No application code changed — this is an operational remediation — so no new automated tests were added per the task guidelines.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@rajshah4 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8aa88097-ce7f-4bc3-9f3e-7d746faef8e6)