### PR TITLE
fix: resolve stale lockfile on service1 (closes #163)

### DIFF
--- a/incidents/2026-06-03-issue-163-stale-lockfile.md
+++ b/incidents/2026-06-03-issue-163-stale-lockfile.md
@@ -1,0 +1,70 @@
+# Incident Report: Issue #163 — Stale Lockfile on service1
+
+**Date**: 2026-06-03  
+**Severity**: High (Service Down)  
+**Skill Used**: `stale-lockfile`  
+**Status**: Resolved ✅
+
+## Diagnosis
+
+`get_all_service_status` output:
+```json
+{
+  "service1": { "path": "/service1", "http_code": "500", "healthy": false },
+  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
+  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
+}
+```
+
+`diagnose_service1` output:
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1"
+}
+```
+
+Root cause: `/tmp/service.lock` was left behind from a previous crash, preventing service1 from starting cleanly.
+
+## Risk Assessment
+
+| Action | Risk Level | Rationale |
+|--------|------------|-----------|
+| `get_all_service_status` | LOW | Read-only health check |
+| `diagnose_service1` | LOW | Read-only diagnostic |
+| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes a temp lockfile only; auto-approved per AGENTS.md |
+| `get_all_service_status` (verification) | LOW | Read-only health check |
+
+## Remediation
+
+`fix_service1` output:
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+## Verification
+
+`get_all_service_status` after fix:
+```json
+{
+  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
+  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
+  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
+}
+```
+
+All services healthy. Issue resolved.


### PR DESCRIPTION
## Skill Used
`stale-lockfile` — `.agents/skills/stale-lockfile/SKILL.md`

## Summary
Fixes #163 — service1 was returning HTTP 500 due to a stale `/tmp/service.lock` left from a previous crash.

## Diagnosis

`get_all_service_status` (before fix):
```json
{
  "service1": { "path": "/service1", "http_code": "500", "healthy": false },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

`diagnose_service1`:
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

Root cause: `/tmp/service.lock` persisted from a previous crash, blocking service1 startup.

## Risk Assessment

| Action | Risk | Rationale |
|--------|------|-----------|
| `get_all_service_status` | LOW | Read-only health check |
| `diagnose_service1` | LOW | Read-only diagnostic |
| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes temp lockfile only; auto-approved per AGENTS.md |
| `get_all_service_status` (verify) | LOW | Read-only health check |

## Remediation

`fix_service1` output:
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

## Verification

`get_all_service_status` (after fix):
```json
{
  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

All services healthy. The existing integration test `test_stale_lockfile_recovers_500_to_200` in `tests/test_integration.py` already covers this exact recovery scenario.

---
_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@rajshah4 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ed34f36e-10fe-48dd-a9e6-63f16258b301)