### PR TITLE
fix: resolve stale lockfile causing service1 HTTP 500 (fixes #166)

### DIFF
--- a/incidents/2026-06-11-issue-166-stale-lockfile.md
+++ b/incidents/2026-06-11-issue-166-stale-lockfile.md
@@ -1,0 +1,71 @@
+# Incident Report: Issue #166 — Stale Lockfile on service1
+
+**Date**: 2026-06-11
+**Severity**: High (Service Down)
+**Skill Used**: `stale-lockfile`
+**Status**: Resolved ✅
+
+## Diagnosis
+
+`get_all_service_status` output:
+```json
+{
+  "service1": { "path": "/service1", "http_code": "500", "healthy": false },
+  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
+  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
+}
+```
+
+`diagnose_service1` output:
+```json
+{
+  "service": "service1",
+  "scenario": "stale_lockfile",
+  "http_status": "500",
+  "healthy": false,
+  "lock_file_exists": true,
+  "diagnosis": "Stale lockfile present - needs removal",
+  "recommended_action": "fix_service1",
+  "next_step": "IMPORTANT: Call the fix_service1 tool NOW to remove the lockfile. This is MEDIUM risk and auto-approved per AGENTS.md."
+}
+```
+
+Root cause: `/tmp/service.lock` was left behind from a previous crash, preventing service1 from starting cleanly.
+
+## Risk Assessment
+
+| Action | Risk Level | Rationale |
+|--------|------------|-----------|
+| `get_all_service_status` | LOW | Read-only health check |
+| `diagnose_service1` | LOW | Read-only diagnostic |
+| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes a temp lockfile only; auto-approved per AGENTS.md |
+| `get_all_service_status` (verification) | LOW | Read-only health check |
+
+## Remediation
+
+`fix_service1` output:
+```json
+{
+  "service": "service1",
+  "action": "rm -f /tmp/service.lock",
+  "risk_level": "MEDIUM",
+  "pre_http_status": "500",
+  "post_http_status": "200",
+  "fixed": true,
+  "rm_returncode": 0,
+  "rm_error": null
+}
+```
+
+## Verification
+
+`get_all_service_status` after fix:
+```json
+{
+  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
+  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
+  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
+}
+```
+
+All services healthy. Issue resolved.

--- a/tests/test_stale_lockfile.py
+++ b/tests/test_stale_lockfile.py
@@ -1,0 +1,68 @@
+"""Unit tests for the stale lockfile scenario (issue #166).
+
+These tests verify that service1 returns HTTP 500 when a stale lockfile is
+present and HTTP 200 after the lockfile is removed — without requiring Docker.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Make the target_service package importable
+TARGET_SERVICE_DIR = Path(__file__).resolve().parents[1] / "target_service"
+sys.path.insert(0, str(TARGET_SERVICE_DIR))
+
+import app as service_app  # noqa: E402
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    """Flask test client with LOCKFILE redirected to a temp directory."""
+    lock = str(tmp_path / "service.lock")
+    monkeypatch.setattr(service_app, "LOCKFILE", lock)
+    service_app.app.config["TESTING"] = True
+    with service_app.app.test_client() as c:
+        yield c, lock
+
+
+def test_service1_returns_500_when_lockfile_present(client):
+    """service1 must return 500 while the stale lockfile exists."""
+    test_client, lock_path = client
+    Path(lock_path).touch()
+
+    response = test_client.get("/service1", headers={"User-Agent": "curl/7.x"})
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["status"] == "error"
+    assert "lockfile" in data["reason"]
+
+
+def test_service1_returns_200_after_lockfile_removed(client):
+    """service1 must return 200 once the stale lockfile has been removed."""
+    test_client, lock_path = client
+    # Simulate the fix: lockfile never created (or already removed)
+    assert not Path(lock_path).exists()
+
+    response = test_client.get("/service1", headers={"User-Agent": "curl/7.x"})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+
+
+def test_service1_recovers_after_lockfile_deleted(client):
+    """service1 recovers from 500 → 200 after the lockfile is deleted."""
+    test_client, lock_path = client
+
+    # Step 1: create lockfile → expect 500
+    Path(lock_path).touch()
+    before = test_client.get("/service1", headers={"User-Agent": "curl/7.x"})
+    assert before.status_code == 500
+
+    # Step 2: remove lockfile → expect 200
+    Path(lock_path).unlink()
+    after = test_client.get("/service1", headers={"User-Agent": "curl/7.x"})
+    assert after.status_code == 200
+    assert after.get_json()["status"] == "ok"


### PR DESCRIPTION
## Skill Used

**stale-lockfile** — 

## Summary

Fixes #166 — service1 was returning HTTP 500 due to a stale `/tmp/service.lock` left from a previous crash.

## Diagnosis

`get_all_service_status` (before fix):
```json
{
  "service1": { "path": "/service1", "http_code": "500", "healthy": false },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

`diagnose_service1`:
```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1",
  "next_step": "IMPORTANT: Call the fix_service1 tool NOW to remove the lockfile. This is MEDIUM risk and auto-approved per AGENTS.md."
}
```

**Root cause**: `/tmp/service.lock` was left behind from a previous crash, preventing service1 from starting cleanly.

## Risk Assessment

| Action | Risk Level | Rationale |
|--------|------------|-----------|
| `get_all_service_status` | LOW | Read-only health check |
| `diagnose_service1` | LOW | Read-only diagnostic |
| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes temp lockfile only; auto-approved per AGENTS.md |
| `get_all_service_status` (verify) | LOW | Read-only health check |

## Remediation

`fix_service1` output:
```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

## Verification

`get_all_service_status` (after fix):
```json
{
  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

All services healthy. 

## Changes

- Created incident report: `incidents/2026-06-11-issue-166-stale-lockfile.md`
- Added unit tests: `tests/test_stale_lockfile.py`
  - `test_service1_returns_500_when_lockfile_present`
  - `test_service1_returns_200_after_lockfile_removed`
  - `test_service1_recovers_after_lockfile_deleted`

The integration test `test_stale_lockfile_recovers_500_to_200` in `tests/test_integration.py` already covers this recovery scenario end-to-end.

---

_This pull request was created by an AI agent (OpenHands) on behalf of the user._