### PR TITLE
fix: resolve stale lockfile causing service1 HTTP 500 (fixes #171)

### DIFF
--- a/tests/test_stale_lockfile.py
+++ b/tests/test_stale_lockfile.py
@@ -1,0 +1,74 @@
+"""Unit tests for stale lockfile scenario (service1 / /service1 endpoint)."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+# Allow importing target_service.app without a Docker container
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "target_service"))
+
+import app as service_app  # noqa: E402
+
+LOCKFILE = service_app.LOCKFILE
+
+
+class StaleLockfileUnitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        """Use Flask test client; ensure lockfile is absent before each test."""
+        self.client = service_app.app.test_client()
+        self._remove_lockfile()
+
+    def tearDown(self) -> None:
+        self._remove_lockfile()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def _remove_lockfile(self) -> None:
+        try:
+            os.remove(LOCKFILE)
+        except FileNotFoundError:
+            pass
+
+    def _create_lockfile(self) -> None:
+        Path(LOCKFILE).touch()
+
+    # ------------------------------------------------------------------
+    # tests
+    # ------------------------------------------------------------------
+
+    def test_service1_returns_200_when_no_lockfile(self) -> None:
+        """Without a lockfile, /service1 must be healthy (HTTP 200)."""
+        resp = self.client.get("/service1", headers={"Accept": "application/json"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertEqual(data["status"], "ok")
+
+    def test_service1_returns_500_when_lockfile_present(self) -> None:
+        """With a stale lockfile, /service1 must return HTTP 500."""
+        self._create_lockfile()
+        resp = self.client.get("/service1", headers={"Accept": "application/json"})
+        self.assertEqual(resp.status_code, 500)
+        data = resp.get_json()
+        self.assertEqual(data["status"], "error")
+        self.assertIn("stale lockfile", data["reason"])
+
+    def test_service1_recovers_after_lockfile_removal(self) -> None:
+        """After removing the lockfile, /service1 must recover to HTTP 200."""
+        self._create_lockfile()
+        broken = self.client.get("/service1", headers={"Accept": "application/json"})
+        self.assertEqual(broken.status_code, 500)
+
+        self._remove_lockfile()
+
+        fixed = self.client.get("/service1", headers={"Accept": "application/json"})
+        self.assertEqual(fixed.status_code, 200)
+        data = fixed.get_json()
+        self.assertEqual(data["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Skill Used
`stale-lockfile` (`.agents/skills/stale-lockfile/SKILL.md`)

Fixes #171

---

## Diagnosis

`get_all_service_status` confirmed service1 was returning HTTP 500:

```json
{
  "service1": { "path": "/service1", "http_code": "500", "healthy": false },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

`diagnose_service1` confirmed the root cause — a stale lockfile at `/tmp/service.lock`:

```json
{
  "service": "service1",
  "scenario": "stale_lockfile",
  "http_status": "500",
  "healthy": false,
  "lock_file_exists": true,
  "diagnosis": "Stale lockfile present - needs removal",
  "recommended_action": "fix_service1"
}
```

---

## Risk Assessment

| Action | Risk | Rationale |
|--------|------|-----------|
| `get_all_service_status` | LOW | Read-only health check |
| `diagnose_service1` | LOW | Read-only file/status check |
| `fix_service1` (`rm -f /tmp/service.lock`) | MEDIUM | Removes only a temp lockfile; auto-approved per AGENTS.md |
| `get_all_service_status` (verify) | LOW | Read-only health check |

---

## Remediation

`fix_service1` executed successfully:

```json
{
  "service": "service1",
  "action": "rm -f /tmp/service.lock",
  "risk_level": "MEDIUM",
  "pre_http_status": "500",
  "post_http_status": "200",
  "fixed": true,
  "rm_returncode": 0,
  "rm_error": null
}
```

---

## Verification

`get_all_service_status` after fix:

```json
{
  "service1": { "path": "/service1", "http_code": "200", "healthy": true },
  "service2": { "path": "/service2", "http_code": "200", "healthy": true },
  "service3": { "path": "/service3", "http_code": "200", "healthy": true }
}
```

All services healthy. ✅

---

## Tests Added

`tests/test_stale_lockfile.py` — unit tests using Flask's test client (no Docker required):

- `test_service1_returns_200_when_no_lockfile` — healthy baseline
- `test_service1_returns_500_when_lockfile_present` — reproduces the incident
- `test_service1_recovers_after_lockfile_removal` — verifies the fix

All 3 tests pass. ✅

---

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@rajshah4 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1b1111fb-b83e-41b0-9e07-3cd1c753ec2f)